### PR TITLE
Change the readme to specify a ref for your for of the websocket gem that contains the 'from_rack' method

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add this line to your application's Gemfile:
 gem 'tubesock'
 # currently, the ability to setup a websocket from rack is only
 # available on my fork. If/when the PR is merged this will become a gem dependency
-gem 'websocket', github: "ngauthier/websocket-ruby", ref: "8fc3bbc8f336fb5ccac95b8707e8146e86a8002d"
+gem 'websocket', github: "ngauthier/websocket-ruby", ref: "dba36ef89e6278949837d5439102cedf595e4208"
 ```
 
 And then execute:


### PR DESCRIPTION
Been playing around with tubesock this afternoon, and it took me a while to figure out why it was only working with v0.0.1 . I had copy + pasted the gemfile lines from the readme, so 'from_rack' wasn't being found. Not sure if you wanted to keep it pointing to a ref or just to the head, but I went ahead and replaced the ref with a suitable one
