### PR TITLE
Add a closed? method to Tubesock

### DIFF
--- a/lib/tubesock.rb
+++ b/lib/tubesock.rb
@@ -72,6 +72,10 @@ class Tubesock
     @socket.close unless @socket.closed?
   end
 
+  def closed?
+    @socket.closed?
+  end
+
   def keepalive
     thread = Thread.new do
       Thread.current.abort_on_exception = true


### PR DESCRIPTION
For long-running threads, it can be necessary to check the socket closed state from within a handler to catch clients closing the connection prematurely.
