### PR TITLE
Rescue Bad file descriptor in tubesock.close

### DIFF
--- a/lib/tubesock.rb
+++ b/lib/tubesock.rb
@@ -106,7 +106,7 @@ class Tubesock
         end
       end
     end
-  rescue Errno::EHOSTUNREACH, Errno::ETIMEDOUT, Errno::ECONNRESET, IOError
+  rescue Errno::EHOSTUNREACH, Errno::ETIMEDOUT, Errno::ECONNRESET, IOError, Errno::EBADF
     nil # client disconnected or timed out
   end
 end


### PR DESCRIPTION
Under Puma, calling `tubesock.close` programmatically causes an exception:

```
Exiting
/usr/local/var/rbenv/versions/1.9.3-p547/lib/ruby/gems/1.9.1/gems/tubesock-0.2.3/lib/tubesock.rb:96:in `select': Bad file descriptor (Errno::EBADF)
  from /usr/local/var/rbenv/versions/1.9.3-p547/lib/ruby/gems/1.9.1/gems/tubesock-0.2.3/lib/tubesock.rb:96:in `each_frame'
  from /usr/local/var/rbenv/versions/1.9.3-p547/lib/ruby/gems/1.9.1/gems/tubesock-0.2.3/lib/tubesock.rb:63:in `block in listen'
```

As raised originally by @tyrbo here: https://github.com/ngauthier/tubesock/issues/23

This PR doesn't actually fix the overall problem of websockets not closing client-side, but it does at least stop Puma from crashing. 
