### PR TITLE
Rescue Errno::ETIMEDOUT in #send_data

### DIFF
--- a/lib/tubesock.rb
+++ b/lib/tubesock.rb
@@ -39,7 +39,7 @@ class Tubesock
       type: type
     )
     @socket.write frame.to_s
-  rescue IOError, Errno::EPIPE
+  rescue IOError, Errno::EPIPE, Errno::ETIMEDOUT
     close
   end
 


### PR DESCRIPTION
This PR fixes crash under puma, full error was: 
```
shared/bundle/ruby/2.2.0/gems/tubesock-0.2.5/lib/tubesock.rb:41:in `write': Connection timed out (Errno::ETIMEDOUT)
```