### PR TITLE
fix multiple close call

### DIFF
--- a/lib/tubesock.rb
+++ b/lib/tubesock.rb
@@ -14,6 +14,8 @@ class Tubesock
     @open_handlers    = []
     @message_handlers = []
     @close_handlers   = []
+    
+    @active = true
   end
 
   def self.hijack(env)
@@ -68,12 +70,16 @@ class Tubesock
   end
 
   def close
+    return unless @active
+    
     @close_handlers.each(&:call)
     if @socket.respond_to?(:closed?)
       @socket.close unless @socket.closed?
     else
       @socket.close
     end
+    
+    @active = false
   end
 
   def closed?


### PR DESCRIPTION
If controller logs sockets for example in `onopen` callback and adds them for further processing, e.g. count open connections or reply to client by id. There is a chance of multiple calls of `#close` method.

Client A opens connection. We put his socket for later processing.
Client A refreshes the site, first time tubesock calls `#close`
Server still sends some information as it has that socket and got rescued in `#send_data` which again calls `#close`

We had another issue where only one websocket session can be opened for a client, we check whether we have active connection and if yes, send text that old session is being closed, and call `#close`. So in our app it is being called three times.

Proposed guard fixes that problem.