### PR TITLE
Close unconditionally without calling close_handlers

### DIFF
--- a/lib/tubesock.rb
+++ b/lib/tubesock.rb
@@ -93,13 +93,17 @@ class Tubesock
     return unless @active
 
     @close_handlers.each(&:call)
+    close!
+
+    @active = false
+  end
+  
+  def close!
     if @socket.respond_to?(:closed?)
       @socket.close unless @socket.closed?
     else
       @socket.close
     end
-
-    @active = false
   end
 
   def closed?


### PR DESCRIPTION
For cases when `@close_on_error` is false and one want to close the socket manually