### PR TITLE
Call open_handlers outside thread

### DIFF
--- a/lib/tubesock.rb
+++ b/lib/tubesock.rb
@@ -70,9 +70,9 @@ class Tubesock
 
   def listen
     keepalive
+    @open_handlers.each(&:call)
     Thread.new do
       begin
-        @open_handlers.each(&:call)
         each_frame do |data|
           @message_handlers.each do |h|
             begin

--- a/lib/tubesock.rb
+++ b/lib/tubesock.rb
@@ -70,9 +70,14 @@ class Tubesock
 
   def listen
     keepalive
-    @open_handlers.each(&:call)
     Thread.new do
       begin
+        begin
+          @open_handlers.each(&:call)
+        rescue => e
+          @error_handlers.each{|eh| eh.call(e)}
+          close if @close_on_error
+        end
         each_frame do |data|
           @message_handlers.each do |h|
             begin

--- a/lib/tubesock.rb
+++ b/lib/tubesock.rb
@@ -72,12 +72,7 @@ class Tubesock
     keepalive
     Thread.new do
       begin
-        begin
-          @open_handlers.each(&:call)
-        rescue => e
-          @error_handlers.each{|eh| eh.call(e)}
-          close if @close_on_error
-        end
+        call_open_handlers
         each_frame do |data|
           @message_handlers.each do |h|
             begin
@@ -94,6 +89,13 @@ class Tubesock
     end
   end
 
+  def call_open_handlers
+    @open_handlers.each(&:call)
+  rescue => e
+    @error_handlers.each{|eh| eh.call(e)}
+    close if @close_on_error
+  end
+
   def close
     return unless @active
 
@@ -102,7 +104,7 @@ class Tubesock
 
     @active = false
   end
-  
+
   def close!
     if @socket.respond_to?(:closed?)
       @socket.close unless @socket.closed?

--- a/test/tubesock_test.rb
+++ b/test/tubesock_test.rb
@@ -137,6 +137,22 @@ class TubesockTest < Tubesock::TestCase
     interaction.close
   end
 
+  def test_exceptions_passed_to_error_handlers_on_open_handler
+    interaction = TestInteraction.new
+
+    errored = MockProc.new
+
+    interaction.tubesock do |tubesock|
+      tubesock.onerror &errored
+      tubesock.onopen do
+        raise "Error opening socket"
+      end
+    end
+
+    interaction.join
+    errored.called.must_equal true
+  end
+
   def test_close_on_open_handler
     interaction = TestInteraction.new
 
@@ -149,7 +165,7 @@ class TubesockTest < Tubesock::TestCase
       end
     end
 
-    proc {interaction.join}.must_raise RuntimeError
+    interaction.join
     closed.called.must_equal true
   end
 


### PR DESCRIPTION
open_handlers exceptions are silently swallowed when inside thread.
setting `abort_on_exception` inside that thread is not a solution.