### PR TITLE
Fix `env` deprecated in Rails 5.0

### DIFF
--- a/lib/tubesock/hijack.rb
+++ b/lib/tubesock/hijack.rb
@@ -33,7 +33,7 @@ module Tubesock::Hijack
         ActiveRecord::Base.clear_active_connections! if defined? ActiveRecord
       end
       sock.listen
-      render text: nil, status: -1
+      render plain: nil, status: -1
     end
   end
 end

--- a/lib/tubesock/hijack.rb
+++ b/lib/tubesock/hijack.rb
@@ -27,7 +27,7 @@ module Tubesock::Hijack
 
   included do
     def hijack
-      sock = Tubesock.hijack(env)
+      sock = Tubesock.hijack(request.env)
       yield sock
       sock.onclose do
         ActiveRecord::Base.clear_active_connections! if defined? ActiveRecord


### PR DESCRIPTION
`env` is deprecated in Ralis 5.0 and removed in 5.1, this updates the code to use `request.env` instead: https://github.com/rails/rails/issues/23294