### PR TITLE
handle errors in keepalive

### DIFF
--- a/tubesock.gemspec
+++ b/tubesock.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rack", ">= 1.5.0"
   spec.add_dependency "websocket", ">= 1.1.0"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest", "~> 4.7.3"
   spec.add_development_dependency "simplecov"


### PR DESCRIPTION
Call the error handlers if there's an error in the keepalive method.

This fixes #58 

